### PR TITLE
Partially support management policies in no-fork external client.

### DIFF
--- a/pkg/controller/external_async_nofork.go
+++ b/pkg/controller/external_async_nofork.go
@@ -96,6 +96,14 @@ func WithNoForkAsyncMetricRecorder(r *metrics.MetricRecorder) NoForkAsyncOption 
 	}
 }
 
+// WithNoForkAsyncManagementPolicies configures whether the client should
+// handle management policies.
+func WithNoForkAsyncManagementPolicies(isManagementPoliciesEnabled bool) NoForkAsyncOption {
+	return func(c *NoForkAsyncConnector) {
+		c.isManagementPoliciesEnabled = isManagementPoliciesEnabled
+	}
+}
+
 type noForkAsyncExternal struct {
 	*noForkExternal
 	callback     CallbackProvider

--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -48,10 +48,19 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
                 tjcontroller.WithNoForkAsyncLogger(o.Logger),
                 tjcontroller.WithNoForkAsyncConnectorEventHandler(eventHandler),
                 tjcontroller.WithNoForkAsyncCallbackProvider(ac),
-                tjcontroller.WithNoForkAsyncMetricRecorder(metrics.NewMetricRecorder({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind, mgr, o.PollInterval)))
+                tjcontroller.WithNoForkAsyncMetricRecorder(metrics.NewMetricRecorder({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind, mgr, o.PollInterval)),
+                {{if .FeaturesPackageAlias -}}
+                  tjcontroller.WithNoForkAsyncManagementPolicies(o.Features.Enabled({{ .FeaturesPackageAlias }}EnableAlphaManagementPolicies))
+                {{- end -}}
+                )
               {{- else -}}
-			  tjcontroller.NewNoForkConnector(mgr.GetClient(), o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"], o.OperationTrackerStore, tjcontroller.WithNoForkLogger(o.Logger),
-				tjcontroller.WithNoForkMetricRecorder(metrics.NewMetricRecorder({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind, mgr, o.PollInterval)))
+			  tjcontroller.NewNoForkConnector(mgr.GetClient(), o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"], o.OperationTrackerStore,
+				tjcontroller.WithNoForkLogger(o.Logger),
+				tjcontroller.WithNoForkMetricRecorder(metrics.NewMetricRecorder({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind, mgr, o.PollInterval)),
+				{{if .FeaturesPackageAlias -}}
+				  tjcontroller.WithNoForkManagementPolicies(o.Features.Enabled({{ .FeaturesPackageAlias }}EnableAlphaManagementPolicies))
+				{{- end -}}
+				)
 			  {{- end -}}
 			{{- else -}}
 			tjcontroller.NewConnector(mgr.GetClient(), o.WorkspaceStore, o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"], tjcontroller.WithLogger(o.Logger), tjcontroller.WithConnectorEventHandler(eventHandler),

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -7,6 +7,8 @@ package {{ .APIVersion }}
 import (
 	"github.com/pkg/errors"
 
+    "dario.cat/mergo"
+
 	"github.com/upbound/upjet/pkg/resource"
 	"github.com/upbound/upjet/pkg/resource/json"
 	{{ .Imports }}
@@ -80,6 +82,36 @@ import (
         }
         base := map[string]any{}
         return base, json.TFParser.Unmarshal(p, &base)
+    }
+
+    // GetInitParameters of this {{ .CRD.Kind }}
+    func (tr *{{ .CRD.Kind }}) GetMergedParameters(isBetaManagementPoliciesEnabled bool) (map[string]any, error) {
+        params, err := tr.GetParameters()
+        if err != nil {
+            return nil, errors.Wrapf(err, "cannot get parameters for resource '%q'", tr.GetName())
+        }
+        if !isBetaManagementPoliciesEnabled {
+            return params, nil
+        }
+
+        initParams, err := tr.GetInitParameters()
+        if err != nil {
+            return nil, errors.Wrapf(err, "cannot get init parameters for resource '%q'", tr.GetName())
+        }
+
+        // Note(lsviben): mergo.WithSliceDeepCopy is needed to merge the
+        // slices from the initProvider to forProvider. As it also sets
+        // overwrite to true, we need to set it back to false, we don't
+        // want to overwrite the forProvider fields with the initProvider
+        // fields.
+        err = mergo.Merge(&params, initParams, mergo.WithSliceDeepCopy, func(c *mergo.Config) {
+            c.Overwrite = false
+        })
+        if err != nil {
+            return nil, errors.Wrapf(err, "cannot merge spec.initProvider and spec.forProvider parameters for resource '%q'", tr.GetName())
+        }
+
+        return params, nil
     }
 
     // LateInitialize this {{ .CRD.Kind }} using its observed tfState.

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -21,6 +21,7 @@ type Parameterizable interface {
 	GetParameters() (map[string]any, error)
 	SetParameters(map[string]any) error
 	GetInitParameters() (map[string]any, error)
+	GetMergedParameters(isBetaManagementPoliciesEnabled bool) (map[string]any, error)
 }
 
 // MetadataProvider provides Terraform metadata for the Terraform managed


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

Add support for management policies to no-fork and no-fork-async external clients. This is a standalone PR that doesn't require any changes on provider-aws side. Run `make generate` in provider-aws for changes to take effect.

Currently, updates (after resource creation) to `initProvider` take effect, which is against specification. Next step is to fix it.

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
I have:

- [x] Read and followed Upjet's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

`make reviewable` fails for reasons unrelated to this PR.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I've tested sync and async clients with an IAM Role resource.

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
