### PR TITLE
Add customConverter struct for supporting the Custom Converters

### DIFF
--- a/pkg/config/conversion/conversions.go
+++ b/pkg/config/conversion/conversions.go
@@ -84,3 +84,27 @@ func NewFieldRenameConversion(sourceVersion, sourceField, targetVersion, targetF
 		targetField:    targetField,
 	}
 }
+
+type customConverter func(src, target resource.Managed) error
+
+type customConversion struct {
+	baseConversion
+	customConverter customConverter
+}
+
+func (cc *customConversion) ConvertTerraformed(src, target resource.Managed) (bool, error) {
+	if !cc.Applicable(src, target) {
+		return false, nil
+	}
+	if err := cc.customConverter(src, target); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func NewCustomConverter(sourceVersion, targetVersion string, converter func(src, target resource.Managed) error) Conversion {
+	return &customConversion{
+		baseConversion:  newBaseConversion(sourceVersion, targetVersion),
+		customConverter: converter,
+	}
+}


### PR DESCRIPTION
### Description of your changes

Add customConverter struct for supporting the Custom Converters

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested against the provider-aws conversion functions

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
