### PR TITLE
Add a configuration API parameter for overriding the field names

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -452,6 +452,32 @@ type Resource struct {
 	// useNoForkClient indicates that a no-fork external client should
 	// be generated instead of the Terraform CLI-forking client.
 	useNoForkClient bool
+
+	// OverrideFieldNames allows to manually override the relevant field name to
+	// avoid possible Go struct name conflicts that may occur after Multiversion
+	// CRDs support. During field generation, there may be fields with the same
+	// struct name calculated in the same group. For example, let X and Y
+	// resources in the same API group have a field named Tag. This field is an
+	// object type and the name calculated for the struct to be generated is
+	// TagParameters (for spec) for both resources. To avoid this conflict, upjet
+	// looks at all previously created structs in the package during generation
+	// and if there is a conflict, it puts the Kind name of the related resource
+	// in front of the next one: YTagParameters.
+	// With Multiversion CRDs support, the above conflict scenario cannot be
+	// solved in the generator when the old API group is preserved and not
+	// regenerated, because the generator does not know the object names in the
+	// old version. For example, a new API version is generated for resource X. In
+	// this case, no generation is done for the old version of X and when Y is
+	// generated, the generator is not aware of the TagParameters in X and
+	// generates TagParameters instead of YTagParameters. Thus, two object types
+	// with the same name are generated in the same package. This can be overcome
+	// by using this configuration API.
+	// The key of the map indicates the name of the field that is generated and
+	// causes the conflict, while the value indicates the name used to avoid the
+	// conflict. By convention, also used in upjet, the field name is preceded by
+	// the value of the generated Kind, for example:
+	// "TagParameters": "ClusterTagParameters"
+	OverrideFieldNames map[string]string
 }
 
 func (r *Resource) ShouldUseNoForkClient() bool {

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -131,7 +131,7 @@ func (g *Builder) buildResource(res *schema.Resource, cfg *config.Resource, tfPa
 	// we need to process all fields in the same order all the time.
 	keys := sortedKeys(res.Schema)
 
-	typeNames, err := NewTypeNames(names, g.Package)
+	typeNames, err := NewTypeNames(names, g.Package, cfg.OverrideFieldNames)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -319,20 +319,20 @@ type TypeNames struct {
 }
 
 // NewTypeNames returns a new TypeNames object.
-func NewTypeNames(fieldPaths []string, pkg *types.Package) (*TypeNames, error) {
-	paramTypeName, err := generateTypeName("Parameters", pkg, fieldPaths...)
+func NewTypeNames(fieldPaths []string, pkg *types.Package, overrideFieldNames map[string]string) (*TypeNames, error) {
+	paramTypeName, err := generateTypeName("Parameters", pkg, overrideFieldNames, fieldPaths...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot generate parameters type name of %s", fieldPath(fieldPaths))
 	}
 	paramName := types.NewTypeName(token.NoPos, pkg, paramTypeName, nil)
 
-	initTypeName, err := generateTypeName("InitParameters", pkg, fieldPaths...)
+	initTypeName, err := generateTypeName("InitParameters", pkg, overrideFieldNames, fieldPaths...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot generate init parameters type name of %s", fieldPath(fieldPaths))
 	}
 	initName := types.NewTypeName(token.NoPos, pkg, initTypeName, nil)
 
-	obsTypeName, err := generateTypeName("Observation", pkg, fieldPaths...)
+	obsTypeName, err := generateTypeName("Observation", pkg, overrideFieldNames, fieldPaths...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot generate observation type name of %s", fieldPath(fieldPaths))
 	}
@@ -447,8 +447,11 @@ func (r *resource) addReferenceFields(g *Builder, paramName *types.TypeName, fie
 // generateTypeName generates a unique name for the type if its original name
 // is used by another one. It adds the former field names recursively until it
 // finds a unique name.
-func generateTypeName(suffix string, pkg *types.Package, names ...string) (string, error) {
+func generateTypeName(suffix string, pkg *types.Package, overrideFieldNames map[string]string, names ...string) (string, error) {
 	n := names[len(names)-1] + suffix
+	if v, ok := overrideFieldNames[n]; ok {
+		return v, nil
+	}
 	for i := len(names) - 2; i >= 0; i-- {
 		if pkg.Scope().Lookup(n) == nil {
 			return n, nil

--- a/pkg/types/builder_test.go
+++ b/pkg/types/builder_test.go
@@ -180,7 +180,7 @@ func TestBuilder_generateTypeName(t *testing.T) {
 			g := &Builder{
 				Package: p,
 			}
-			got, gotErr := generateTypeName(tc.args.suffix, g.Package, tc.args.names...)
+			got, gotErr := generateTypeName(tc.args.suffix, g.Package, map[string]string{}, tc.args.names...)
 			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
 				t.Fatalf("generateTypeName(...): -want error, +got error: %s", diff)
 			}


### PR DESCRIPTION
### Description of your changes

This PR adds a configuration API parameter for overriding the field names

I have:

- [ ] Read and followed Upjet's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested against the aws autoscaling.GroupTag that we know causes this type of collision.

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
